### PR TITLE
Restrict user privileges on Posts

### DIFF
--- a/Tabloid/client/src/components/Posts/DeletePost.js
+++ b/Tabloid/client/src/components/Posts/DeletePost.js
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useContext } from "react";
 import { PostContext } from "../../providers/PostProvider";
+import { UserProfileContext } from "../../providers/UserProfileProvider";
 import { useHistory, useParams } from "react-router-dom";
 import { Container, Row, Button } from "reactstrap";
 
 const DeletePost = (props) => {
 
     const { getPost, deletePost } = useContext(PostContext);
+    const { isAdministrator } = useContext(UserProfileContext);
     const { id } = useParams();
 
     const [post, setPost] = useState();
@@ -13,7 +15,15 @@ const DeletePost = (props) => {
     const history = useHistory();
 
     useEffect(() => {
-        getPost(id).then((res) => setPost(res));
+        const loggedInUser = JSON.parse(sessionStorage.userProfile);
+        getPost(id).then((res) => {
+            if (res.userProfileId != loggedInUser.id && !isAdministrator) {
+                // Kick back to post list if another user reaches this area
+                history.push("/post");
+            } else {
+            setPost(res);
+            }
+        })
     }, []);
 
     if (!post) {

--- a/Tabloid/client/src/components/Posts/DeletePost.js
+++ b/Tabloid/client/src/components/Posts/DeletePost.js
@@ -11,6 +11,7 @@ const DeletePost = (props) => {
     const { id } = useParams();
 
     const [post, setPost] = useState();
+    const [isLoaded, setIsLoaded] = useState(false);
 
     const history = useHistory();
 
@@ -22,6 +23,7 @@ const DeletePost = (props) => {
                 history.push("/post");
             } else {
             setPost(res);
+            setIsLoaded(true);
             }
         })
     }, []);
@@ -71,7 +73,7 @@ const DeletePost = (props) => {
 
                 <Row>
                     <Button color="primary" onClick={confirmDelete}>Delete</Button>
-                    <Button color="primary" onClick={() => history.goBack()}>Cancel</Button>
+                    <Button color="primary" onClick={() => history.goBack()} disabled={!isLoaded} >Cancel</Button>
                 </Row>
             </section>
         </Container>

--- a/Tabloid/client/src/components/Posts/EditPost.js
+++ b/Tabloid/client/src/components/Posts/EditPost.js
@@ -84,7 +84,7 @@ const EditPost = (props) => {
         const currentUser = JSON.parse(sessionStorage.userProfile);
         getCategories();
         getPost(id).then((res) => {
-            if (res.userProfileId != currentUser.id) {
+            if (res.userProfileId !== currentUser.id) {
                 // Kick back to previous page if another user reaches this area
                 history.push("/post");
             } else {

--- a/Tabloid/client/src/components/Posts/EditPost.js
+++ b/Tabloid/client/src/components/Posts/EditPost.js
@@ -26,8 +26,7 @@ const EditPost = (props) => {
         imageLocation: false,
         categoryId: false
     });
-    const [currentUser, setCurrentUser] = useState();
-
+    const [isLoaded, setIsLoaded] = useState(false);
 
     const { id } = useParams();
     const history = useHistory();
@@ -82,14 +81,15 @@ const EditPost = (props) => {
     }
 
     useEffect(() => {
-        const loggedInUser = JSON.parse(sessionStorage.userProfile);
+        const currentUser = JSON.parse(sessionStorage.userProfile);
         getCategories();
         getPost(id).then((res) => {
-            if (res.userProfileId != loggedInUser.id) {
+            if (res.userProfileId != currentUser.id) {
                 // Kick back to previous page if another user reaches this area
                 history.push("/post");
             } else {
-            setEditedPost(res);
+                setEditedPost(res);
+                setIsLoaded(true);
             }
         })
     }, []);
@@ -158,7 +158,7 @@ const EditPost = (props) => {
                         <Button className="primary" disabled={!isFormValid}>Submit</Button>
                     </Col>
                     <Col sm={1}>
-                        <Button className="secondary" type="button" onClick={() => history.goBack()}>Cancel</Button>
+                        <Button className="secondary" type="button" onClick={() => history.goBack()} disabled={!isLoaded} >Cancel</Button>
                     </Col>
                 </FormGroup>
             </Form>

--- a/Tabloid/client/src/components/Posts/Post.js
+++ b/Tabloid/client/src/components/Posts/Post.js
@@ -1,9 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext } from "react";
 import { Link, useHistory } from "react-router-dom";
 import { Button } from "reactstrap";
+import { UserProfileContext } from "../../providers/UserProfileProvider";
 
 const Post = ({ post, currentUser }) => {
 
+    const { isAdministrator } = useContext(UserProfileContext);
     const history = useHistory();
 
     return (
@@ -23,9 +25,9 @@ const Post = ({ post, currentUser }) => {
                 {(currentUser === post.userProfile.id)
                     ? <Button color="primary" onClick={() => history.push(`/post/${post.id}/edit`)}>Edit</Button>
                     : null}
-                {(currentUser === post.userProfile.id || isAdmin)
-                ? <Button color="primary" onClick={() => history.push(`/post/${post.id}/delete`)}>Delete</Button>
-                : null
+                {(currentUser === post.userProfile.id || isAdministrator)
+                    ? <Button color="primary" onClick={() => history.push(`/post/${post.id}/delete`)}>Delete</Button>
+                    : null
                 }
             </td>
         </tr>

--- a/Tabloid/client/src/components/Posts/Post.js
+++ b/Tabloid/client/src/components/Posts/Post.js
@@ -23,8 +23,10 @@ const Post = ({ post, currentUser }) => {
                 {(currentUser === post.userProfile.id)
                     ? <Button color="primary" onClick={() => history.push(`/post/${post.id}/edit`)}>Edit</Button>
                     : null}
-                <Button color="primary" onClick={() => history.push(`/post/${post.id}/delete`)}>Delete</Button>
-
+                {(currentUser === post.userProfile.id || isAdmin)
+                ? <Button color="primary" onClick={() => history.push(`/post/${post.id}/delete`)}>Delete</Button>
+                : null
+                }
             </td>
         </tr>
     )

--- a/Tabloid/client/src/components/Posts/Post.js
+++ b/Tabloid/client/src/components/Posts/Post.js
@@ -10,6 +10,7 @@ const Post = ({ post, currentUser }) => {
 
     return (
         <tr>
+            {console.log(isAdministrator)}
             <td>
                 <Link to={`/post/${post.id}/details`} >
                     <strong>{post.title}</strong>

--- a/Tabloid/client/src/components/Posts/PostDetails.js
+++ b/Tabloid/client/src/components/Posts/PostDetails.js
@@ -7,7 +7,7 @@ import { UserProfileContext } from "../../providers/UserProfileProvider";
 const PostDetails = (props) => {
 
     const { getPost, getTagsByPostId } = useContext(PostContext);
-    const { getToken } = useContext(UserProfileContext);
+    const { getToken, isAdministrator } = useContext(UserProfileContext);
     
     const { id } = useParams();
 
@@ -123,8 +123,12 @@ const PostDetails = (props) => {
                 <Row>
                     {currentUser
                         ? <Button color="primary" onClick={() => history.push(`/post/${post.id}/edit`)}>Edit</Button>
-                        : null}
-                    <Button color="primary" onClick={() => history.push(`/post/${post.id}/delete`)}>Delete</Button>
+                        : null
+                    }
+                    {currentUser || isAdministrator
+                        ? <Button color="primary" onClick={() => history.push(`/post/${post.id}/delete`)}>Delete</Button>
+                        : null
+                    }
                     <Button onClick={() => history.push(`/post/tags/${id}`)}>Manage Tags</Button>
                 </Row>
             </section>

--- a/Tabloid/client/src/components/Posts/PostDetails.js
+++ b/Tabloid/client/src/components/Posts/PostDetails.js
@@ -43,7 +43,10 @@ const PostDetails = (props) => {
         }
 
         getPost(id).then((res) => {
-            if (loggedInUser.id === res.userProfileId) {
+            console.log(res)
+            if (loggedInUser.id !== res.userProfileId && (!res.publishDateTime || !res.isApproved)) {
+                history.push("/post");
+            } else if (loggedInUser.id === res.userProfileId) {
                 setCurrentUser(true);
             }
             checkSubscription(res.userProfileId).then(setIsSubscribed);

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -10,6 +10,7 @@ export function UserProfileProvider(props) {
 
   const userProfile = sessionStorage.getItem("userProfile");
   const [isLoggedIn, setIsLoggedIn] = useState(userProfile != null);
+  const [isAdministrator, setIsAdministrator] = useState(false);
 
   const [isFirebaseReady, setIsFirebaseReady] = useState(false);
   useEffect(() => {
@@ -23,6 +24,7 @@ export function UserProfileProvider(props) {
       .then((signInResponse) => getUserProfile(signInResponse.user.uid))
       .then((userProfile) => {
         sessionStorage.setItem("userProfile", JSON.stringify(userProfile));
+        setIsAdministrator(userProfile.userTypeId === 1);
         setIsLoggedIn(true);
       });
   };
@@ -69,7 +71,7 @@ export function UserProfileProvider(props) {
   };
 
   return (
-    <UserProfileContext.Provider value={{ isLoggedIn, login, logout, register, getToken }}>
+    <UserProfileContext.Provider value={{ isLoggedIn, isAdministrator, login, logout, register, getToken }}>
       {isFirebaseReady
         ? props.children
         : <Spinner className="app-spinner dark" />}

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -10,7 +10,8 @@ export function UserProfileProvider(props) {
 
   const userProfile = sessionStorage.getItem("userProfile");
   const [isLoggedIn, setIsLoggedIn] = useState(userProfile != null);
-  const [isAdministrator, setIsAdministrator] = useState(false);
+  const [isAdministrator, setIsAdministrator] = useState(userProfile != null && JSON.parse(userProfile).userTypeId === 1);
+  // isAdministrator can be used throughout the app to check the user's authorization level
 
   const [isFirebaseReady, setIsFirebaseReady] = useState(false);
   useEffect(() => {


### PR DESCRIPTION
# Description
Per James's request, tightened the following in Posts:
- Made Delete buttons unavailable to Authors on other users' posts
- Users cannot automatically navigate to another user's posts manually to edit
- Authors cannot manually navigate to another user's posts to delete
As part of the resolution of this issue, I created an isAdministrator state in UserProfileContext. This is accessible throughout the site to quickly and simply check the current user's administrator status.
Partially addresses #34 
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
1. Checkout, fix appsettings, run, etc.
2. Login as an author
3. Edit and Delete for other user's posts should not be visible in the browser
4. Try to get to the edit or delete page of another user's post. It should kick back to the post list
5. Login as an Admin
6. Try to get to the edit page of another user's post. It should kick back to the post list. 
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works